### PR TITLE
Add named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type SourceLocation = {
 const LF = '\n';
 const CR = '\r';
 
-export default class LinesAndColumns {
+class LinesAndColumns {
   private string: string;
   private offsets: Array<number>;
 
@@ -75,3 +75,6 @@ export default class LinesAndColumns {
     return nextOffset - offset;
   }
 }
+
+export { LinesAndColumns };
+export default LinesAndColumns;


### PR DESCRIPTION
Hey, @eventualbuddha !

The default export compiled with TS as:

```js
exports["default"] = LinesAndColumns;
```

it creates a problem with native supported `import/export` in Node.js v16. 

```js
// This import returns an `undefined` in Node.js >= 16 type=module
import LinesAndColumns from 'lines-and-columns';
```

We should use the next way.

```js
import { createRequire } from 'node:module';

const require = createRequire(import.meta.url);
const LinesAndColumns = require('lines-and-columns').default;
```

The named export fix this issue.

```js
import { LinesAndColumns } from 'lines-and-columns';
```