### PR TITLE
ci(release): use node v14

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
`semantic-release` requires node v14 or higher.