### PR TITLE
Add `types` field to `exports` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "main": "./build/index.cjs",
   "exports": {
     "import": "./build/index.mjs",
-    "require": "./build/index.cjs"
+    "require": "./build/index.cjs",
+    "types": "./build/index.d.ts"
   },
   "types": "./build/index.d.ts",
   "files": [


### PR DESCRIPTION
When we set `moduleResolution` to `Node16` in `tsconfig.json`, following error is occurred by tsc:

```
Could not find a declaration file for module 'lines-and-columns'. '/Users/sosuke.suzuki/ghq/github.com/prettier/angular-estree-parser/node_modules/lines-and-columns/build/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/sosuke.suzuki/ghq/github.com/prettier/angular-estree-parser/node_modules/lines-and-columns/build/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'lines-and-columns' library may need to update its package.json or typings.

1 import { LinesAndColumns } from 'lines-and-columns';
                                  ~~~~~~~~~~~~~~~~~~~
```

You can declaration type information by adding a types field to exports.