### PR TITLE
fix: add `types` field to `exports` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "main": "./build/index.cjs",
   "exports": {
     "import": "./build/index.mjs",
-    "require": "./build/index.cjs"
+    "require": "./build/index.cjs",
+    "types": "./build/index.d.ts"
   },
   "types": "./build/index.d.ts",
   "files": [


### PR DESCRIPTION
Replacement for https://github.com/eventualbuddha/lines-and-columns/pull/217, since I needed to change the commit message but couldn't on @sosukesuzuki's fork.